### PR TITLE
Update compat with Symbolics 2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
           - '1.5'
           - '1.6'
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.1.0"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+SymbolicUtils = "d1185830-fcd6-423d-90d6-eec64667417b"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 OrderedCollections = "1.4"
+SymbolicUtils = "0.13.0 - 0.13.1"
 Symbolics = "0.1, 1, 2"
-julia = "1.4"
+julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
 OrderedCollections = "1.4"
-Symbolics = "0.1, 1"
+Symbolics = "0.1, 1, 2"
 julia = "1.4"
 
 [extras]


### PR DESCRIPTION
- Supersedes and closes #5
- Bumps minimum Julia to 1.5.
- Limit SymbolicUtils to 0.13.1 because 0.13.2 introduces a bug (see https://github.com/bocklund/Calphad.jl/issues/6)
- Nightly builds failing due to https://github.com/JuliaSymbolics/Symbolics.jl/issues/290